### PR TITLE
Makefile uses configurable CUDA paths and arch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,11 @@ CXX=g++ -w -m64 -std=c++11
 CXXFLAGS = -O3 -Wall -Wno-unknown-pragmas
 CVFLAGS=$(shell pkg-config --cflags --libs opencv)
 
-LDFLAGS=-L/usr/local/cuda-8.0/lib64/ -lcudart
-INCLUDE=/usr/local/cuda-8.0/include
-NVCCFLAGS=-O3 -m64 --gpu-architecture compute_35
+CUDA_HOME ?= /usr/local/cuda
+ARCH ?= compute_80
+LDFLAGS = -L$(CUDA_HOME)/lib64 -lcudart
+INCLUDE = $(CUDA_HOME)/include
+NVCCFLAGS = -O3 -m64 --gpu-architecture $(ARCH)
 NVCC=nvcc
 
 default: $(APPNAME)


### PR DESCRIPTION
## Summary
- add `CUDA_HOME` and `ARCH` variables to Makefile
- use those variables for nvcc flags, include, and lib directories
- allow overriding CUDA paths and architecture via environment variables

## Testing
- `make -n bm3d | head`

------
https://chatgpt.com/codex/tasks/task_e_6852b6d985908330a15dac4610af39cc